### PR TITLE
Added support for service job type

### DIFF
--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/NomadStepPlugin.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/NomadStepPlugin.java
@@ -55,7 +55,8 @@ public abstract class NomadStepPlugin implements StepPlugin, Describable {
                             String.format("%s.driver.%s.%sPropertyComposer",
                                     this.getClass().getPackage().getName(),
                                     driverName.toLowerCase(),
-                                    driverName)).newInstance();
+                                    driverName))
+                            .newInstance();
             PropertyComposer nomadPropertyComposer = new NomadPropertyComposer();
             return driverPropertyComposer
                     .compose(nomadPropertyComposer)
@@ -172,8 +173,9 @@ public abstract class NomadStepPlugin implements StepPlugin, Describable {
             eval.getFailedTgAllocs()
                     .get(TASK_GROUP_RUNDECK)
                     .getDimensionExhausted()
+                    .keySet()
                     .forEach(
-                    (k, v) -> logger.log(0,
+                    k -> logger.log(0,
                             String.format("Evaluation blocked due to %s", k)));
             throw new StepException(
                     String.format("Error while processing evaluation: %s", evalId),

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/NomadStepPlugin.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/NomadStepPlugin.java
@@ -41,7 +41,6 @@ import static io.github.valfadeev.rundeck_nomad_plugin.nomad.NomadConfigOptions.
 
 public abstract class NomadStepPlugin implements StepPlugin, Describable {
 
-    private static final String JOB_TYPE_BATCH = "batch";
     private static final String TASK_GROUP_RUNDECK = "rundeck";
 
     private final String driverName = this.getClass().getAnnotation(Driver.class).name();
@@ -135,6 +134,8 @@ public abstract class NomadStepPlugin implements StepPlugin, Describable {
                     Reason.PluginInternalFailure);
         }
 
+        String jobType = configuration.get(NOMAD_JOB_TYPE).toString();
+
         Job job = NomadJobProvider.getJob(
                 configuration,
                 agentConfig,
@@ -142,8 +143,7 @@ public abstract class NomadStepPlugin implements StepPlugin, Describable {
                 driverName.toLowerCase(),
                 rundeckJobId,
                 rundeckJobName,
-                TASK_GROUP_RUNDECK,
-                JOB_TYPE_BATCH);
+                TASK_GROUP_RUNDECK);
 
         JobsApi jobsApi = apiClient.getJobsApi();
         String evalId;
@@ -182,8 +182,6 @@ public abstract class NomadStepPlugin implements StepPlugin, Describable {
                     String.format("Error while processing evaluation: %s", evalId),
                     Reason.EvalBlockedFailure);
         }
-
-        String jobType = configuration.get(NOMAD_JOB_TYPE).toString();
 
         if (jobType.equals("batch")) {
             logger.log(2, String.format("Evauation %s is complete, waiting for allocations", evalId));

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/common/PropertyComposer.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/common/PropertyComposer.java
@@ -10,6 +10,10 @@ public class PropertyComposer {
         this.builder = DescriptionBuilder.builder();
     }
 
+    protected DescriptionBuilder addProperties(DescriptionBuilder builder) {
+        return builder;
+    }
+
     public DescriptionBuilder getBuilder() {
         return this.addProperties(builder);
     }
@@ -17,9 +21,5 @@ public class PropertyComposer {
     public PropertyComposer compose(PropertyComposer other) {
         this.builder = other.getBuilder();
         return this;
-    }
-
-    protected DescriptionBuilder addProperties(DescriptionBuilder builder) {
-        return builder;
     }
 }

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/driver/docker/DockerTaskConfigProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/driver/docker/DockerTaskConfigProvider.java
@@ -175,7 +175,7 @@ public class DockerTaskConfigProvider implements TaskConfigProvider {
         }
 
         if (!dockerPortMapString.isEmpty()) {
-            List<Map<String, String >> portMapList = new ArrayList<>();
+            List<Map<String, String>> portMapList = new ArrayList<>();
             portMapList.add(ParseInput.kvToMap(dockerPortMapString));
             taskConfig.put("port_map", portMapList);
         }

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadConfigOptions.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadConfigOptions.java
@@ -5,6 +5,7 @@ public class NomadConfigOptions {
     public static final String NOMAD_DATACENTER = "nomad_datacenter";
     public static final String NOMAD_REGION = "nomad_region";
     public static final String NOMAD_GROUP_COUNT = "nomad_group_count";
+    public static final String NOMAD_JOB_TYPE = "nomad_job_type";
     public static final String NOMAD_MAX_FAIL_PCT = "nomad_max_fail_pct";
     public static final String NOMAD_ENV_VARS = "nomad_env_vars";
     public static final String NOMAD_DYNAMIC_PORTS = "nomad_dynamic_ports";

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadJobProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadJobProvider.java
@@ -20,8 +20,7 @@ public class NomadJobProvider {
                              String driver,
                              String id,
                              String name,
-                             String taskGroupName,
-                             String jobType) {
+                             String taskGroupName) {
 
         Map<String, String> env = NomadTaskEnvProvider.getEnv(configuration);
         Resources resources = NomadTaskResourcesProvider.getResources(configuration);
@@ -58,6 +57,8 @@ public class NomadJobProvider {
         if (region.isEmpty()) {
             region = agentConfig.get("Region").toString();
         }
+
+        String jobType = configuration.get(NOMAD_JOB_TYPE).toString();
 
         return new Job()
                 .setId(id)

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadPropertyComposer.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadPropertyComposer.java
@@ -47,6 +47,17 @@ public class NomadPropertyComposer extends PropertyComposer {
                         .build()
                 )
                 .property(PropertyBuilder.builder()
+                        .select(NOMAD_JOB_TYPE)
+                        .title("Type of job")
+                        .description("Specifies the Nomad scheduler to use.")
+                        .required(true)
+                        .values("batch",
+                                "service"
+                        )
+                        .defaultValue("batch")
+                        .build()
+                )
+                .property(PropertyBuilder.builder()
                         .longType(NOMAD_MAX_FAIL_PCT)
                         .title("Max allowed failed instances, %")
                         .description("Maximum number of job allocations allowed to fail")

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadTaskNetworkResourcesProvider.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadTaskNetworkResourcesProvider.java
@@ -42,7 +42,8 @@ public class NomadTaskNetworkResourcesProvider {
                 .get(NOMAD_RESERVED_PORTS)
                 .toString();
         if (!reservedPortString.isEmpty()) {
-            List<Port> reservedPorts = ParseInput.kvToMap(reservedPortString)
+            List<Port> reservedPorts = ParseInput
+                    .kvToMap(reservedPortString)
                     .entrySet()
                     .stream()
                     .map(m -> new Port()

--- a/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/util/ParseInput.java
+++ b/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/util/ParseInput.java
@@ -11,7 +11,8 @@ public class ParseInput {
             return result;
         } else {
             throw new IllegalArgumentException(
-                    String.format("valid input must be a string delimited by \"%s\", got: \"%s\"",
+                    String.format("valid input must be a string "
+                                + "delimited by \"%s\", got: \"%s\"",
                             delimiter, input));
         }
 

--- a/src/test/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadJobProviderTest.java
+++ b/src/test/java/io/github/valfadeev/rundeck_nomad_plugin/nomad/NomadJobProviderTest.java
@@ -22,6 +22,7 @@ public class NomadJobProviderTest {
                 .addItem(NOMAD_DATACENTER, "")
                 .addItem(NOMAD_REGION, "")
                 .addItem(NOMAD_GROUP_COUNT, "3")
+                .addItem(NOMAD_JOB_TYPE, "service")
                 .addItem(NOMAD_MAX_FAIL_PCT, "0")
                 .addItem(NOMAD_ENV_VARS, "FOO=BAR")
                 .addItem(NOMAD_TASK_CPU, "50")
@@ -46,15 +47,14 @@ public class NomadJobProviderTest {
                 "docker",
                 "testId",
                 "testName",
-                "rundeck",
-                "batch");
+                "rundeck");
 
         assertThat(job.getDatacenters(), is(Arrays.asList(new String[]{"dc1"})));
         assertThat(job.getId(), is("testId"));
         assertThat(job.getName(), is("testName"));
         assertThat(job.getTaskGroups().get(0).getName(), is("rundeck"));
-        assertThat(job.getType(), is("batch"));
         assertThat(job.getRegion(), is("global"));
+        assertThat(job.getType(), is("service"));
     }
 
 }


### PR DESCRIPTION
addresses https://github.com/ValFadeev/rundeck-nomad-plugin/issues/3 in the simplest possible way: there is no "handover" process, assuming that the appropriate runtime monitoring mechanisms kick in after deployment